### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/thisofficialonline/8f43d6d9-dddb-4f82-904d-01f9bbd73122/3ee04e7d-866b-4075-a159-48ca30b26843/_apis/work/boardbadge/8d5ff15c-5d6b-4609-b90a-2f6e0244444f)](https://dev.azure.com/thisofficialonline/8f43d6d9-dddb-4f82-904d-01f9bbd73122/_boards/board/t/3ee04e7d-866b-4075-a159-48ca30b26843/Microsoft.RequirementCategory)
 # Azure Terraform Quickstart template
 
 Use this template to easily create a new Git Repository for managing Jenkins X cloud infrastructure needs.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/thisofficialonline/8f43d6d9-dddb-4f82-904d-01f9bbd73122/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.